### PR TITLE
Organize blog posts into directory and add card listing

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -1,10 +1,10 @@
-
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
   <title>Blog | Hackney Construction</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet" />
   <link href="styles.css" rel="stylesheet" />
 </head>
 <body>
@@ -14,35 +14,74 @@
   </header>
 
   <section class="container py-5">
-    <div class="mb-5">
-      <h2><a href="post5.html">🌧️ Leaky Roofs After Iowa's Summer Storms</a></h2>
-      <p><em>Posted July 2024</em></p>
-      <p>Recent heavy rains are revealing leaks across the state. Find out what to check and how quick repairs protect your home...</p>
-    </div>
-    <div class="mb-5">
-      <h2><a href="post1.html">💨 What to Do After a Windstorm Hits Your Roof</a></h2>
-      <p><em>Posted April 2024</em></p>
-      <p>Learn how to inspect your home for damage, document it, and contact your roofer fast. Don’t let wind compromise your roof without you knowing...</p>
-    </div>
+    <div class="row">
 
-    <div class="mb-5">
-      <h2><a href="post2.html">🌨️ How Hail Damages Shingles (and How to Spot It)</a></h2>
-      <p><em>Posted March 2024</em></p>
-      <p>Hail might leave no visible holes — but it still bruises shingles. Find out what damage to look for, how it shortens roof life, and what to do about it...</p>
-    </div>
-  
-    <div class="mb-5">
-      <h2><a href="post3.html">🌿 Why Fresh Roof Is a Game-Changer for Asphalt Shingles</a></h2>
-      <p><em>Posted February 2024</em></p>
-      <p>Want to avoid a full replacement? Fresh Roof rejuvenates old shingles using a soy-based spray that extends roof life for a fraction of the cost...</p>
-    </div>
+      <article class="col-md-6 col-lg-4 mb-4">
+        <a href="blog/post5.html" class="text-decoration-none text-dark">
+          <div class="card h-100 shadow-sm border-0">
+            <img src="images/overhead.jpg" class="card-img-top" alt="Roof with rain water" />
+            <div class="card-body">
+              <p class="text-muted small mb-1">Posted July 2024</p>
+              <h3 class="card-title">🌧️ Leaky Roof After the Storm? Here’s What to Do</h3>
+              <p class="card-text">Recent storms across Iowa have drenched roofs and exposed weak spots...</p>
+            </div>
+          </div>
+        </a>
+      </article>
 
-    <div class="mb-5">
-      <h2><a href="post4.html">🚩 5 Questions to Ask Before Hiring a Traveling Roofer</a></h2>
-      <p><em>Posted January 2024</em></p>
-      <p>Storm chasers move fast after hail hits — but not all of them stick around. Ask these five questions before signing anything...</p>
-    </div>
+      <article class="col-md-6 col-lg-4 mb-4">
+        <a href="blog/post1.html" class="text-decoration-none text-dark">
+          <div class="card h-100 shadow-sm border-0">
+            <img src="images/project1.jpg" class="card-img-top" alt="Windstorm roof inspection" />
+            <div class="card-body">
+              <p class="text-muted small mb-1">Posted April 2024</p>
+              <h3 class="card-title">💨 What to Do After a Windstorm Hits Your Roof</h3>
+              <p class="card-text">Windstorms can do more damage than you might think — especially to older shingles...</p>
+            </div>
+          </div>
+        </a>
+      </article>
 
-</section>
+      <article class="col-md-6 col-lg-4 mb-4">
+        <a href="blog/post2.html" class="text-decoration-none text-dark">
+          <div class="card h-100 shadow-sm border-0">
+            <img src="images/project2.jpg" class="card-img-top" alt="Close-up of hail damaged shingles" />
+            <div class="card-body">
+              <p class="text-muted small mb-1">Posted March 2024</p>
+              <h3 class="card-title">🌨️ How Hail Damages Shingles (and How to Spot It)</h3>
+              <p class="card-text">Hail damage doesn’t always look dramatic, but the impacts can shorten the life of your roof...</p>
+            </div>
+          </div>
+        </a>
+      </article>
+
+      <article class="col-md-6 col-lg-4 mb-4">
+        <a href="blog/post3.html" class="text-decoration-none text-dark">
+          <div class="card h-100 shadow-sm border-0">
+            <img src="images/project3.jpg" class="card-img-top" alt="Fresh Roof treatment on asphalt shingles" />
+            <div class="card-body">
+              <p class="text-muted small mb-1">Posted February 2024</p>
+              <h3 class="card-title">🌿 Why Fresh Roof Is a Game-Changer for Asphalt Shingles</h3>
+              <p class="card-text">Fresh Roof is a soy-based roof rejuvenation spray that restores shingle flexibility...</p>
+            </div>
+          </div>
+        </a>
+      </article>
+
+      <article class="col-md-6 col-lg-4 mb-4">
+        <a href="blog/post4.html" class="text-decoration-none text-dark">
+          <div class="card h-100 shadow-sm border-0">
+            <img src="images/project4.jpg" class="card-img-top" alt="Contractor shaking hands with homeowner" />
+            <div class="card-body">
+              <p class="text-muted small mb-1">Posted January 2024</p>
+              <h3 class="card-title">🚩 5 Questions to Ask Before Hiring a Traveling Roofer</h3>
+              <p class="card-text">After big storms, out-of-town roofers — aka “storm chasers” — swarm small towns with fast offers...</p>
+            </div>
+          </div>
+        </a>
+      </article>
+
+    </div>
+  </section>
 </body>
 </html>

--- a/blog/post-template.html
+++ b/blog/post-template.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title><!-- Post Title --> | Hackney Construction Blog</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="../styles.css" rel="stylesheet" />
+</head>
+<body>
+  <header class="bg-dark text-white text-center py-4">
+    <h1><!-- Post Title --></h1>
+    <p><a href="../blog.html" style="color: #F4D35E;">← Back to Blog</a></p>
+  </header>
+
+  <section class="container py-5">
+    <!-- Post content -->
+  </section>
+</body>
+</html>

--- a/blog/post1.html
+++ b/blog/post1.html
@@ -5,12 +5,13 @@
   <meta charset="UTF-8" />
   <title>After a Windstorm | Hackney Construction Blog</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link href="styles.css" rel="stylesheet" />
+  <link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="../styles.css" rel="stylesheet" />
 </head>
 <body>
   <header class="bg-dark text-white text-center py-4">
     <h1>💨 What to Do After a Windstorm Hits Your Roof</h1>
-    <p><a href="blog.html" style="color: #F4D35E;">← Back to Blog</a></p>
+    <p><a href="../blog.html" style="color: #F4D35E;">← Back to Blog</a></p>
   </header>
 
   <section class="container py-5">

--- a/blog/post2.html
+++ b/blog/post2.html
@@ -5,12 +5,13 @@
   <meta charset="UTF-8" />
   <title>Hail Damage Guide | Hackney Construction Blog</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link href="styles.css" rel="stylesheet" />
+  <link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="../styles.css" rel="stylesheet" />
 </head>
 <body>
   <header class="bg-dark text-white text-center py-4">
     <h1>🌨️ How Hail Damages Shingles (and How to Spot It)</h1>
-    <p><a href="blog.html" style="color: #F4D35E;">← Back to Blog</a></p>
+    <p><a href="../blog.html" style="color: #F4D35E;">← Back to Blog</a></p>
   </header>
 
   <section class="container py-5">

--- a/blog/post3.html
+++ b/blog/post3.html
@@ -5,12 +5,13 @@
   <meta charset="UTF-8" />
   <title>Why Fresh Roof Is a Game-Changer | Hackney Construction Blog</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link href="styles.css" rel="stylesheet" />
+  <link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="../styles.css" rel="stylesheet" />
 </head>
 <body>
   <header class="bg-dark text-white text-center py-4">
     <h1>🌿 Why Fresh Roof Is a Game-Changer for Asphalt Shingles</h1>
-    <p><a href="blog.html" style="color: #F4D35E;">← Back to Blog</a></p>
+    <p><a href="../blog.html" style="color: #F4D35E;">← Back to Blog</a></p>
   </header>
 
   <section class="container py-5">

--- a/blog/post4.html
+++ b/blog/post4.html
@@ -5,12 +5,13 @@
   <meta charset="UTF-8" />
   <title>Questions to Ask Storm Chasers | Hackney Construction Blog</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link href="styles.css" rel="stylesheet" />
+  <link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="../styles.css" rel="stylesheet" />
 </head>
 <body>
   <header class="bg-dark text-white text-center py-4">
     <h1>🚩 5 Questions to Ask Before Hiring a Traveling Roofer</h1>
-    <p><a href="blog.html" style="color: #F4D35E;">← Back to Blog</a></p>
+    <p><a href="../blog.html" style="color: #F4D35E;">← Back to Blog</a></p>
   </header>
 
   <section class="container py-5">

--- a/blog/post5.html
+++ b/blog/post5.html
@@ -5,12 +5,13 @@
   <title>Fixing Leaky Roofs After Iowa Storms | Hackney Construction Blog</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Tips to stop roof leaks after recent Iowa storms and protect your home." />
-  <link href="styles.css" rel="stylesheet" />
+  <link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="../styles.css" rel="stylesheet" />
 </head>
 <body>
   <header class="bg-dark text-white text-center py-4">
     <h1>🌧️ Leaky Roof After the Storm? Here’s What to Do</h1>
-    <p><a href="blog.html" style="color: #F4D35E;">← Back to Blog</a></p>
+    <p><a href="../blog.html" style="color: #F4D35E;">← Back to Blog</a></p>
   </header>
 
   <section class="container py-5">


### PR DESCRIPTION
## Summary
- Move all blog posts into a new `blog/` directory and add a `post-template.html` for future entries.
- Refresh `blog.html` into a card-based grid with images, metadata, titles and excerpts linking to the new posts.
- Update relative paths for styles and navigation so posts point back to the blog index and shared assets.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bae8de388329b18ceea68eab7a8e