### PR TITLE
Specify image dimensions for images and logos

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -21,7 +21,7 @@ header{position:sticky;top:0;z-index:50;background:#fff;border-bottom:1px solid 
 .grid{display:grid;gap:26px}
 .grid-3{grid-template-columns:repeat(3,minmax(0,1fr))}
 .grid-2{grid-template-columns:repeat(2,minmax(0,1fr))}
-.card{background:#fff;border:1px solid #eef2f5;border-radius:12px;overflow:hidden;box-shadow:0 2px 10px rgba(0,0,0,.04)}
+.card{background:#fff;border:1px solid #eef2f5;border-radius:12px;overflow:hidden;box-shadow:0 2px 10px rgba(0,0,0,.04)}.card img{display:block;width:100%;height:auto}
 .card .pad{padding:20px}
 .card h3{margin:0 0 .25rem;color:var(--primary)}
 .badge{display:inline-flex;align-items:center;gap:8px;background:#0ea5e980;color:#065a82;padding:6px 10px;border-radius:999px;font:700 12px/1 Montserrat,Arial}
@@ -37,7 +37,7 @@ header{position:sticky;top:0;z-index:50;background:#fff;border-bottom:1px solid 
 .footer{background:#0f172a;color:#e5e7eb}
 .footer a{color:#e5e7eb}
 .footer .columns{display:grid;gap:28px;grid-template-columns:2fr 1fr 1fr 1.2fr}
-.footer small{color:#9ca3af}
+.footer small{color:#9ca3af}.footer img{height:40px;width:auto}
 @media (max-width:960px){.grid-3{grid-template-columns:1fr 1fr}.grid-2{grid-template-columns:1fr}.footer .columns{grid-template-columns:1fr 1fr}.process::before{display:none}.step{grid-template-columns:64px 1fr}}
 @media (max-width:640px){.mobile-hide{display:none}.kpis{grid-template-columns:1fr}}
 

--- a/blog.html
+++ b/blog.html
@@ -18,8 +18,8 @@
 
       <article class="col-md-6 col-lg-4 mb-4">
         <a href="blog/post5.html" class="text-decoration-none text-dark">
-          <div class="card h-100 shadow-sm border-0">
-            <img src="images/overhead.jpg" class="card-img-top" alt="Roof with rain water" />
+            <div class="card h-100 shadow-sm border-0">
+              <img src="images/overhead.jpg" class="card-img-top" alt="Roof with rain water" width="1080" height="801" />
             <div class="card-body">
               <p class="text-muted small mb-1">Posted July 2024</p>
               <h3 class="card-title">🌧️ Leaky Roof After the Storm? Here’s What to Do</h3>
@@ -31,8 +31,8 @@
 
       <article class="col-md-6 col-lg-4 mb-4">
         <a href="blog/post1.html" class="text-decoration-none text-dark">
-          <div class="card h-100 shadow-sm border-0">
-            <img src="images/project1.jpg" class="card-img-top" alt="Windstorm roof inspection" />
+            <div class="card h-100 shadow-sm border-0">
+              <img src="images/project1.jpg" class="card-img-top" alt="Windstorm roof inspection" width="4000" height="1848" />
             <div class="card-body">
               <p class="text-muted small mb-1">Posted April 2024</p>
               <h3 class="card-title">💨 What to Do After a Windstorm Hits Your Roof</h3>
@@ -44,8 +44,8 @@
 
       <article class="col-md-6 col-lg-4 mb-4">
         <a href="blog/post2.html" class="text-decoration-none text-dark">
-          <div class="card h-100 shadow-sm border-0">
-            <img src="images/project2.jpg" class="card-img-top" alt="Close-up of hail damaged shingles" />
+            <div class="card h-100 shadow-sm border-0">
+              <img src="images/project2.jpg" class="card-img-top" alt="Close-up of hail damaged shingles" width="4000" height="1848" />
             <div class="card-body">
               <p class="text-muted small mb-1">Posted March 2024</p>
               <h3 class="card-title">🌨️ How Hail Damages Shingles (and How to Spot It)</h3>
@@ -57,8 +57,8 @@
 
       <article class="col-md-6 col-lg-4 mb-4">
         <a href="blog/post3.html" class="text-decoration-none text-dark">
-          <div class="card h-100 shadow-sm border-0">
-            <img src="images/project3.jpg" class="card-img-top" alt="Fresh Roof treatment on asphalt shingles" />
+            <div class="card h-100 shadow-sm border-0">
+              <img src="images/project3.jpg" class="card-img-top" alt="Fresh Roof treatment on asphalt shingles" width="4000" height="1848" />
             <div class="card-body">
               <p class="text-muted small mb-1">Posted February 2024</p>
               <h3 class="card-title">🌿 Why Fresh Roof Is a Game-Changer for Asphalt Shingles</h3>
@@ -70,8 +70,8 @@
 
       <article class="col-md-6 col-lg-4 mb-4">
         <a href="blog/post4.html" class="text-decoration-none text-dark">
-          <div class="card h-100 shadow-sm border-0">
-            <img src="images/project4.jpg" class="card-img-top" alt="Contractor shaking hands with homeowner" />
+            <div class="card h-100 shadow-sm border-0">
+              <img src="images/project4.jpg" class="card-img-top" alt="Contractor shaking hands with homeowner" width="768" height="856" />
             <div class="card-body">
               <p class="text-muted small mb-1">Posted January 2024</p>
               <h3 class="card-title">🚩 5 Questions to Ask Before Hiring a Traveling Roofer</h3>

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 <header>
   <div class="container nav" role="navigation" aria-label="Main">
     <a class="brand" href="/">
-      <img src="images/SawLogo_White.png" alt="Hackney Roofing logo" />
+      <img src="images/SawLogo_White.png" alt="Hackney Roofing logo" width="3600" height="2709" />
       <span class="title"><b>HACKNEY ROOFING</b><small>Roof Repair • Replacement • Fresh Roof</small></span>
     </a>
     <nav class="mobile-hide" aria-label="Primary">
@@ -67,7 +67,7 @@
         </ul>
         <p style="margin-top:12px"><a class="btn" href="#quote">Check if your roof qualifies</a></p>
       </div>
-      <div class="card"><img src="images/project2.jpg" alt="Technician applying roof rejuvenation coating"></div>
+      <div class="card"><img src="images/project2.jpg" alt="Technician applying roof rejuvenation coating" width="4000" height="1848"></div>
     </div>
   </section>
 
@@ -75,9 +75,9 @@
     <div class="container">
       <h2>Services</h2>
       <div class="grid grid-3" style="margin-top:24px">
-        <article class="card" aria-labelledby="svc1"><img src="images/project3.jpg" alt="Asphalt roof shingles closeup"><div class="pad"><h3 id="svc1">Roof Repair</h3><p>Leaks, storm damage, flashing, vents, and problem valleys—fixed right and fast.</p></div></article>
-        <article class="card" aria-labelledby="svc2"><img src="images/project4.jpg" alt="Crew replacing a roof"><div class="pad"><h3 id="svc2">Full Replacement</h3><p>Architectural shingles or metal. Proper ventilation, ice & water, and manufacturer specs.</p></div></article>
-        <article class="card" aria-labelledby="svc3"><img src="images/project5.jpg" alt="Metal standing seam roof"><div class="pad"><h3 id="svc3">Metal Roofing</h3><p>Standing seam and metal shingles for long life, energy efficiency, and clean looks.</p></div></article>
+          <article class="card" aria-labelledby="svc1"><img src="images/project3.jpg" alt="Asphalt roof shingles closeup" width="4000" height="1848"><div class="pad"><h3 id="svc1">Roof Repair</h3><p>Leaks, storm damage, flashing, vents, and problem valleys—fixed right and fast.</p></div></article>
+          <article class="card" aria-labelledby="svc2"><img src="images/project4.jpg" alt="Crew replacing a roof" width="768" height="856"><div class="pad"><h3 id="svc2">Full Replacement</h3><p>Architectural shingles or metal. Proper ventilation, ice & water, and manufacturer specs.</p></div></article>
+          <article class="card" aria-labelledby="svc3"><img src="images/project5.jpg" alt="Metal standing seam roof" width="768" height="1024"><div class="pad"><h3 id="svc3">Metal Roofing</h3><p>Standing seam and metal shingles for long life, energy efficiency, and clean looks.</p></div></article>
       </div>
     </div>
   </section>
@@ -128,7 +128,7 @@
   <div class="container section">
     <div class="columns">
       <div>
-        <img src="images/SawLogo_White.png" alt="Hackney Roofing logo light" />
+        <img src="images/SawLogo_White.png" alt="Hackney Roofing logo light" width="3600" height="2709" />
         <p>Serving South Central Iowa since 1985. Licensed & insured.</p>
       </div>
       <div>


### PR DESCRIPTION
## Summary
- add explicit width and height attributes to logos and project images across the site
- ensure card and footer images scale correctly via CSS

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c2bb2d5c8329a455ea2b1f21512e