### PR TITLE
feat: improve header contrast for branding

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -4,13 +4,13 @@ a{color:var(--primary);text-decoration:none}a:hover{text-decoration:underline}
 .btn{display:inline-block;background:var(--secondary);color:#fff;padding:.75rem 1.25rem;border-radius:999px;font-weight:700;box-shadow:0 6px 14px var(--ring)}
 .btn:hover{filter:brightness(.95);text-decoration:none}
 .btn-outline{background:#fff;color:var(--secondary);border:2px solid var(--secondary)}
-header{position:sticky;top:0;z-index:50;background:#fff;border-bottom:1px solid #eef2f5}
+header{position:sticky;top:0;z-index:50;background:var(--primary);border-bottom:1px solid #eef2f5}
 .nav{display:flex;align-items:center;justify-content:space-between;padding:12px 0}
-.nav a{font-weight:700;color:#2c3e50}
+.nav a{font-weight:700;color:#fff}
 .brand{display:flex;gap:12px;align-items:center}
 .brand img{height:48px;width:auto}
-.brand .title{display:flex;flex-direction:column}
-.brand .title b{letter-spacing:.5px;color:var(--primary)}
+.brand .title{display:flex;flex-direction:column;color:#fff}
+.brand .title b{letter-spacing:.5px}
 .mobile-hide{display:flex;gap:22px}
 .hero{min-height:78vh;display:grid;place-items:center;background:linear-gradient(rgba(0,0,0,.6),rgba(0,0,0,.6)),url('../images/overhead.jpg') center/cover;color:#fff;text-align:left}
 .hero h1{font:800 40px/1.1 Montserrat,Arial,Helvetica,sans-serif;margin:0 0 12px}
@@ -34,7 +34,7 @@ header{position:sticky;top:0;z-index:50;background:#fff;border-bottom:1px solid 
 .process::before{content:"";position:absolute;left:50%;top:40px;bottom:40px;width:4px;background:linear-gradient(var(--secondary),transparent);transform:translateX(-50%)}
 .step{display:grid;grid-template-columns:80px 1fr;gap:16px;align-items:start}
 .step .num{width:64px;height:64px;border-radius:999px;background:var(--secondary);color:#fff;display:grid;place-items:center;font:800 22px Montserrat;box-shadow:0 10px 18px var(--ring)}
-.footer{background:#0f172a;color:#e5e7eb}
+.footer{background:linear-gradient(135deg,var(--primary),#0f172a);color:#e5e7eb}
 .footer a{color:#e5e7eb}
 .footer .columns{display:grid;gap:28px;grid-template-columns:2fr 1fr 1fr 1.2fr}
 .footer small{color:#9ca3af}.footer img{height:40px;width:auto}


### PR DESCRIPTION
## Summary
- use brand color header for better logo contrast
- switch navigation and brand text to white for readability
- add primary-to-navy gradient footer backdrop

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c5a54de883299eef1564c578fcfa