### PR TITLE
Limit footer logo dimensions for cached CSS

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -37,7 +37,7 @@ header{position:sticky;top:0;z-index:50;background:#fff;border-bottom:1px solid 
 .footer{background:#0f172a;color:#e5e7eb}
 .footer a{color:#e5e7eb}
 .footer .columns{display:grid;gap:28px;grid-template-columns:2fr 1fr 1fr 1.2fr}
-.footer small{color:#9ca3af}.footer img{height:40px;width:auto}
+.footer small{color:#9ca3af}.footer-logo{height:40px;width:auto}
 @media (max-width:960px){.grid-3{grid-template-columns:1fr 1fr}.grid-2{grid-template-columns:1fr}.footer .columns{grid-template-columns:1fr 1fr}.process::before{display:none}.step{grid-template-columns:64px 1fr}}
 @media (max-width:640px){.mobile-hide{display:none}.kpis{grid-template-columns:1fr}}
 

--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
   <div class="container section">
     <div class="columns">
       <div>
-        <img src="images/SawLogo_White.png" alt="Hackney Roofing logo light" width="3600" height="2709" />
+        <img class="footer-logo" src="images/SawLogo_White.png" alt="Hackney Roofing logo light" width="53" height="40" />
         <p>Serving South Central Iowa since 1985. Licensed & insured.</p>
       </div>
       <div>


### PR DESCRIPTION
## Summary
- Shrink footer logo's intrinsic dimensions and add a `footer-logo` class
- Style `footer-logo` with fixed height and auto width to prevent overflow if CSS loads late

## Testing
- `curl -sS http://localhost:8000/index.html | rg 'footer-logo'`

------
https://chatgpt.com/codex/tasks/task_e_68b0c5aff1c08329b33728fb6041838f