### PR TITLE
Improve blog repo detection for custom domains

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8" />
   <title>Blog | Hackney Construction</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="github-owner" content="bohamil" />
+  <meta name="github-repo" content="hanckneyconstruction" />
   <link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet" />
   <link href="styles.css" rel="stylesheet" />
 </head>

--- a/blog.js
+++ b/blog.js
@@ -2,9 +2,15 @@
   const container = document.getElementById('blog-list');
   if (!container) return;
 
-  // Attempt to derive owner and repo from current location
-  let owner = 'USERNAME'; // replace with your GitHub username if using a custom domain
+  // Attempt to derive owner and repo from meta tags or current location
+  let owner = 'bohamil';
   let repo = 'hanckneyconstruction';
+
+  const metaOwner = document.querySelector('meta[name="github-owner"]')?.content;
+  const metaRepo = document.querySelector('meta[name="github-repo"]')?.content;
+  if (metaOwner) owner = metaOwner;
+  if (metaRepo) repo = metaRepo;
+
   const hostname = window.location.hostname;
   if (hostname.endsWith('github.io')) {
     owner = hostname.split('.')[0];


### PR DESCRIPTION
## Summary
- set GitHub owner to `bohamil`
- allow overriding owner/repo via `github-owner`/`github-repo` meta tags
- include meta tags in `blog.html`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check blog.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_68b1d96a4ee0832991bd711d92843aed