### PR TITLE
feat: adjust hero colors

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -12,7 +12,7 @@ header{position:sticky;top:0;z-index:50;background:var(--primary);border-bottom:
 .brand .title{display:flex;flex-direction:column;color:#fff}
 .brand .title b{letter-spacing:.5px}
 .mobile-hide{display:flex;gap:22px}
-.hero{min-height:78vh;display:grid;place-items:center;background:linear-gradient(rgba(0,0,0,.6),rgba(0,0,0,.6)),url('../images/overhead.jpg') center/cover;color:#fff;text-align:left}
+.hero{min-height:78vh;display:grid;place-items:center;background:linear-gradient(rgba(0,0,0,.6),rgba(0,0,0,.6)),url('../images/overhead.jpg') center/cover;color:inherit;text-align:left}
 .hero h1{font:800 40px/1.1 Montserrat,Arial,Helvetica,sans-serif;margin:0 0 12px}
 .hero p{max-width:720px;margin:0 0 22px;font-size:18px}
 .hero .cta{display:flex;gap:12px;flex-wrap:wrap}
@@ -29,7 +29,8 @@ header{position:sticky;top:0;z-index:50;background:var(--primary);border-bottom:
 .icon{width:28px;height:28px;display:inline-grid;place-items:center;border-radius:999px;background:#eef2f5}
 .ul{margin:10px 0 0 18px}
 .kpis{display:grid;gap:18px;grid-template-columns:repeat(3,minmax(0,1fr))}
-.kpi{background:#fff;border:1px dashed #dfe5ea;border-radius:10px;padding:16px;text-align:center;color:var(--ink)}
+.hero .kpi{background:#fff;border:1px dashed #dfe5ea;border-radius:10px;padding:16px;text-align:center;color:var(--ink)}
+.hero .needs-white{color:#fff}
 .kpi b{display:block;font:800 28px/1 Montserrat}
 .process{position:relative}
 .process::before{content:"";position:absolute;left:50%;top:40px;bottom:40px;width:4px;background:linear-gradient(var(--secondary),transparent);transform:translateX(-50%)}


### PR DESCRIPTION
## Summary
- let .hero inherit color instead of forcing white
- scope KPI styling to .hero .kpi and provide .needs-white utility

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2090719d08329a7ebc2fe81a2771b