### PR TITLE
fix: ensure hero text remains white

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,8 +40,8 @@
   <section class="hero" id="home">
     <div class="container">
       <span class="badge" aria-label="Winter is coming">❄ Winter Prep</span>
-      <h1>Fix it before the first freeze.<br/>Roof repair, replacement & <em>Fresh Roof</em> rejuvenation.</h1>
-      <p>Ice, snow, and Iowa freeze–thaw cycles punish old shingles. We’ll inspect this week, prioritize leaks, and—if it’s a fit—rejuvenate your roof to stretch life 10–15 years at a fraction of replacement.</p>
+      <h1 class="needs-white">Fix it before the first freeze.<br/>Roof repair, replacement & <em>Fresh Roof</em> rejuvenation.</h1>
+      <p class="needs-white">Ice, snow, and Iowa freeze–thaw cycles punish old shingles. We’ll inspect this week, prioritize leaks, and—if it’s a fit—rejuvenate your roof to stretch life 10–15 years at a fraction of replacement.</p>
       <div class="cta">
         <a class="btn" href="tel:+16412038046">Call for Free Inspection</a>
         <a class="btn btn-outline" href="#quote">Get a Fast Quote</a>


### PR DESCRIPTION
## Summary
- keep hero headline and supporting paragraph styled in white for readability

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b20e64b2dc8329b0c0405a70db7c09