### PR TITLE
feat: enhance quote form handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,8 @@
         <h2>Get a fast, no‑nonsense quote</h2>
         <p>Tell us your address and a couple photos. We’ll confirm scope and price options.
         Prefer phone? <a href="tel:+16412038046">Call (641) 203‑8046</a>.</p>
-        <form action="https://docs.google.com/forms/d/e/1FAIpQLSerNdb4EiZYupdm0_aVUrafKC5MY5iXztxz56e8s7DD7hmCEw/formResponse" method="post" class="card pad" aria-label="Quote form" id="quote-form">
+        <iframe name="hidden_iframe" id="hidden_iframe" style="display:none;"></iframe>
+        <form action="https://docs.google.com/forms/d/e/1FAIpQLSerNdb4EiZYupdm0_aVUrafKC5MY5iXztxz56e8s7DD7hmCEw/formResponse" method="post" class="card pad" aria-label="Quote form" id="quote-form" target="hidden_iframe">
           <input type="hidden" name="fvv" value="1">
           <label class="visually-hidden" for="name">Name</label>
           <input id="name" name="entry.2005620554" placeholder="Name" style="width:100%;padding:12px;margin-bottom:10px;border:1px solid #dfe5ea;border-radius:8px" required>
@@ -109,11 +110,58 @@
           <label class="visually-hidden" for="address">Address</label>
           <input id="address" name="entry.839337160" placeholder="Address (City, IA)" style="width:100%;padding:12px;margin-bottom:10px;border:1px solid #dfe5ea;border-radius:8px" required>
           <label class="visually-hidden" for="notes">Notes</label>
-          <textarea id="notes" name="notes" placeholder="Leak location, roof age, etc." rows="4" style="width:100%;padding:12px;border:1px solid #dfe5ea;border-radius:8px"></textarea>
+          <textarea id="notes" name="entry.1065046570" placeholder="Leak location, roof age, etc." rows="4" style="width:100%;padding:12px;border:1px solid #dfe5ea;border-radius:8px"></textarea>
           <input type="text" name="website" style="display:none">
-          <button class="btn" type="submit" style="margin-top:10px">Request Quote</button>
+          <button class="btn" id="submitBtn" type="submit" style="margin-top:10px" disabled>Request Quote</button>
         </form>
+        <div id="form-error" role="alert" style="color:#b00020;display:none;"></div>
         <div id="form-status" role="status" aria-live="polite" style="margin-top:10px"></div>
+        <script>
+          const form = document.getElementById('quote-form');
+          const phone = document.getElementById('phone');
+          const statusBox = document.getElementById('form-status');
+          const errorBox = document.getElementById('form-error');
+          const submitBtn = document.getElementById('submitBtn');
+          const digitsOnly = v => (v || '').replace(/\D/g, '');
+          const fmt = d => d.length<=3 ? `(${d}` :
+                        d.length<=6 ? `(${d.slice(0,3)}) ${d.slice(3)}` :
+                        `(${d.slice(0,3)}) ${d.slice(3,6)}-${d.slice(6,10)}`;
+
+          function validate() {
+            const d = digitsOnly(phone.value).slice(0,10);
+            phone.value = fmt(d);
+            const ok = d.length === 10 && form.checkValidity();
+            submitBtn.disabled = !ok;
+            errorBox.style.display = ok ? 'none' : 'block';
+            errorBox.textContent = ok ? '' : 'Phone must be exactly 10 digits.';
+            return ok;
+          }
+
+          phone.addEventListener('input', validate);
+          form.addEventListener('input', validate);
+
+          form.addEventListener('submit', (e) => {
+            if (document.querySelector('input[name="website"]').value || !validate()) {
+              e.preventDefault();
+            } else {
+              window._submittedToGoogle = true;
+              statusBox.textContent = 'Submitting…';
+            }
+          });
+
+          document.getElementById('hidden_iframe').addEventListener('load', () => {
+            if (window._submittedToGoogle) {
+              window._submittedToGoogle = false;
+              form.reset();
+              submitBtn.disabled = true;
+              statusBox.textContent = 'Thanks! We got your request.';
+              errorBox.style.display = 'none';
+              errorBox.textContent = '';
+            }
+          });
+
+          validate();
+        </script>
       </div>
       <aside class="card pad" aria-label="Reasons to act now">
         <h3>Why act before first frost</h3>
@@ -163,13 +211,6 @@
   </div>
 </footer>
 <script src="https://www.google.com/recaptcha/api.js" async defer></script>
-<script>
-  document.querySelector('form').addEventListener('submit', function (e) {
-    if (document.querySelector('input[name="website"]').value) {
-      e.preventDefault();
-    }
-  });
-</script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- Send quote form submissions to a hidden iframe and block spam via honeypot.
- Format and validate phone numbers with inline JavaScript and show error/status messages.
- Disable submit button until the form is valid.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c42e8efbf48329a8afbf94f600a9a2